### PR TITLE
Replace @opentelemetry/tracing with @opentelemetry/sdk-trace-base

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@opentelemetry/context-async-hooks": "^1.0.0",
-        "@opentelemetry/tracing": "^0.24.0",
+        "@opentelemetry/sdk-trace-base": "^1.3.1",
         "@types/better-sqlite3": "^7.4.0",
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
@@ -785,44 +785,36 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-      "integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/core": "0.24.0",
-        "@opentelemetry/semantic-conventions": "0.24.0"
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-      "integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.3.1.tgz",
+      "integrity": "sha512-Or95QZ+9QyvAiwqj+K68z8bDDuyWF50c37w17D10GV1dWzg4Ezcectsu/GB61QcBxm3Y4br0EN5F5TpIFfFliQ==",
       "dev": true,
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "0.24.0",
-        "semver": "^7.1.3"
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/resources": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
       },
       "engines": {
-        "node": ">=8.5.0"
+        "node": ">=8.12.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
-      }
-    },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-      "integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -831,50 +823,6 @@
       "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
       "engines": {
         "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@opentelemetry/tracing": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.24.0.tgz",
-      "integrity": "sha512-sTLEs1SIon3xV8vLe53PzfbU0FahoxL9NPY/CYvA1mwGbMu4zHkHAjqy1Tc8JmqRrfa+XrHkmzeSM4hrvloBaA==",
-      "deprecated": "Package renamed to @opentelemetry/sdk-trace-base",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "0.24.0",
-        "@opentelemetry/resources": "0.24.0",
-        "@opentelemetry/semantic-conventions": "0.24.0",
-        "lodash.merge": "^4.6.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
-      }
-    },
-    "node_modules/@opentelemetry/tracing/node_modules/@opentelemetry/core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-      "integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "0.24.0",
-        "semver": "^7.1.3"
-      },
-      "engines": {
-        "node": ">=8.5.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
-      }
-    },
-    "node_modules/@opentelemetry/tracing/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-      "integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -5953,67 +5901,30 @@
       }
     },
     "@opentelemetry/resources": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-      "integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
+      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
       "dev": true,
       "requires": {
-        "@opentelemetry/core": "0.24.0",
-        "@opentelemetry/semantic-conventions": "0.24.0"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-          "integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/semantic-conventions": "0.24.0",
-            "semver": "^7.1.3"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-          "integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
-          "dev": true
-        }
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
+      }
+    },
+    "@opentelemetry/sdk-trace-base": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.3.1.tgz",
+      "integrity": "sha512-Or95QZ+9QyvAiwqj+K68z8bDDuyWF50c37w17D10GV1dWzg4Ezcectsu/GB61QcBxm3Y4br0EN5F5TpIFfFliQ==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/core": "1.3.1",
+        "@opentelemetry/resources": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.3.1"
       }
     },
     "@opentelemetry/semantic-conventions": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
       "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
-    },
-    "@opentelemetry/tracing": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.24.0.tgz",
-      "integrity": "sha512-sTLEs1SIon3xV8vLe53PzfbU0FahoxL9NPY/CYvA1mwGbMu4zHkHAjqy1Tc8JmqRrfa+XrHkmzeSM4hrvloBaA==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/core": "0.24.0",
-        "@opentelemetry/resources": "0.24.0",
-        "@opentelemetry/semantic-conventions": "0.24.0",
-        "lodash.merge": "^4.6.2"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-          "integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/semantic-conventions": "0.24.0",
-            "semver": "^7.1.3"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-          "integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
-          "dev": true
-        }
-      }
     },
     "@tsconfig/node10": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "typings": "dist/lib/index.d.ts",
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^1.0.0",
-    "@opentelemetry/tracing": "^0.24.0",
+    "@opentelemetry/sdk-trace-base": "^1.3.1",
     "@types/better-sqlite3": "^7.4.0",
     "@types/chai": "^4.2.21",
     "@types/mocha": "^9.0.0",

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2,7 +2,12 @@ import { expect } from 'chai';
 import forEach from 'mocha-each';
 import { SpanStatusCode, context, trace } from '@opentelemetry/api';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
-import { BasicTracerProvider, InMemorySpanExporter, ReadableSpan, SimpleSpanProcessor } from '@opentelemetry/tracing';
+import {
+    BasicTracerProvider,
+    InMemorySpanExporter,
+    ReadableSpan,
+    SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { BetterSqlite3Instrumentation } from '../lib';
 


### PR DESCRIPTION
npm WARN deprecated @opentelemetry/tracing@0.24.0: Package renamed to @opentelemetry/sdk-trace-base