### PR TITLE
feat: add esm support

### DIFF
--- a/lib/better-sqlite3.ts
+++ b/lib/better-sqlite3.ts
@@ -23,10 +23,13 @@ export class BetterSqlite3Instrumentation extends InstrumentationBase {
             new InstrumentationNodeModuleDefinition(
                 'better-sqlite3',
                 supportedVersions,
-                (moduleExports: typeof bs3Types, moduleVersion) => {
+                (moduleExports: typeof bs3Types | { default: typeof bs3Types }, moduleVersion) => {
                     diag.debug(`Applying patch for better-sqlite3@${moduleVersion}`);
 
-                    const proto = moduleExports.prototype;
+                    const proto =
+                        'prototype' in moduleExports
+                            ? moduleExports.prototype
+                            : (moduleExports as { default: typeof bs3Types }).default.prototype;
 
                     // istanbul ignore else
                     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -43,11 +46,15 @@ export class BetterSqlite3Instrumentation extends InstrumentationBase {
 
                     return moduleExports;
                 },
-                (moduleExports: typeof bs3Types, moduleVersion) => {
+                (moduleExports: typeof bs3Types | { default: typeof bs3Types }, moduleVersion) => {
                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, sonarjs/different-types-comparison
                     if (moduleExports !== undefined) {
                         diag.debug(`Removing patch for better-sqlite3@${moduleVersion}`);
-                        this._massUnwrap([moduleExports.prototype], ['exec', 'prepare', 'pragma']);
+                        const proto =
+                            'prototype' in moduleExports
+                                ? moduleExports.prototype
+                                : (moduleExports as { default: typeof bs3Types }).default.prototype;
+                        this._massUnwrap([proto], ['exec', 'prepare', 'pragma']);
                     }
                 },
             ),


### PR DESCRIPTION
I am using ESM in my project `import Database from 'better-sqlite3';` and there right now it crashes as it looks intot he wrong module export path.

with this patch it works as expected
![CleanShot 2025-06-21 at 11 06 17@2x](https://github.com/user-attachments/assets/05fd1f21-0bf7-4181-90d7-31b53c43bb66)
